### PR TITLE
fix category attribute

### DIFF
--- a/mmau-test-mini.json
+++ b/mmau-test-mini.json
@@ -13,7 +13,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -31,7 +33,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -49,7 +53,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -67,7 +73,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -85,7 +93,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -103,7 +113,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -121,7 +133,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -139,7 +153,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -157,7 +173,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -175,7 +193,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -193,7 +213,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -211,7 +233,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -229,7 +253,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -247,7 +273,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -265,7 +293,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -283,7 +313,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -301,7 +333,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -319,7 +353,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -337,7 +373,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -355,7 +393,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -373,7 +413,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -391,7 +433,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -409,7 +453,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -427,7 +473,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -445,7 +493,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -463,7 +513,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -481,7 +533,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -499,7 +553,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -517,7 +573,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -535,7 +593,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -553,7 +613,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -571,7 +633,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -589,7 +653,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -607,7 +673,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -625,7 +693,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -643,7 +713,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -661,7 +733,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -679,7 +753,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -697,7 +773,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -715,7 +793,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -733,7 +813,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -751,7 +833,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -769,7 +853,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -787,7 +873,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -805,7 +893,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -823,7 +913,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -841,7 +933,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -859,7 +953,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Source Inference",
     "difficulty": "medium"
   },
@@ -877,7 +973,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -895,7 +993,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -933,7 +1033,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -951,7 +1053,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -969,7 +1073,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1007,7 +1113,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1025,7 +1133,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1043,7 +1153,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "easy"
   },
@@ -1061,7 +1173,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1099,7 +1213,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1117,7 +1233,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "easy"
   },
@@ -1135,7 +1253,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1153,7 +1273,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1171,7 +1293,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1229,7 +1353,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1247,7 +1373,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1265,7 +1393,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1303,7 +1433,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1321,7 +1453,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1339,7 +1473,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "easy"
   },
@@ -1357,7 +1493,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1375,7 +1513,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1393,7 +1533,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1411,7 +1553,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1429,7 +1573,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1447,7 +1593,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1465,7 +1613,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "easy"
   },
@@ -1483,7 +1633,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1501,7 +1653,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1539,7 +1693,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "easy"
   },
@@ -1657,7 +1813,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "easy"
   },
@@ -1695,7 +1853,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "easy"
   },
@@ -1713,7 +1873,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1731,7 +1893,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "easy"
   },
@@ -1749,7 +1913,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Event Reasoning",
     "difficulty": "hard"
   },
@@ -1766,7 +1932,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1784,7 +1952,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1802,7 +1972,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1820,7 +1992,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1838,7 +2012,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1856,7 +2032,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1874,7 +2052,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1892,7 +2072,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1910,7 +2092,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1928,7 +2112,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1946,7 +2132,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1964,7 +2152,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -1982,7 +2172,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -2000,7 +2192,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -2018,7 +2212,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -2036,7 +2232,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -2054,7 +2252,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -2072,7 +2272,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -2090,7 +2292,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -2108,7 +2312,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -2126,7 +2332,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2144,7 +2352,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2162,7 +2372,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2180,7 +2392,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2198,7 +2412,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2216,7 +2432,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2234,7 +2452,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2252,7 +2472,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2270,7 +2492,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2288,7 +2512,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2306,7 +2532,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2324,7 +2552,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2342,7 +2572,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2360,7 +2592,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2378,7 +2612,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2396,7 +2632,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2414,7 +2652,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2432,7 +2672,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2450,7 +2692,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2468,7 +2712,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -2486,7 +2732,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2504,7 +2752,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2522,7 +2772,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2540,7 +2792,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2558,7 +2812,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2576,7 +2832,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2594,7 +2852,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2612,7 +2872,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2630,7 +2892,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2648,7 +2912,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2666,7 +2932,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2684,7 +2952,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2702,7 +2972,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2720,7 +2992,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2738,7 +3012,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2756,7 +3032,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2774,7 +3052,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2792,7 +3072,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2810,7 +3092,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2828,7 +3112,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -2846,7 +3132,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -2864,7 +3152,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -2882,7 +3172,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -2900,7 +3192,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -2918,7 +3212,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -2936,7 +3232,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -2954,7 +3252,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -2972,7 +3272,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -2990,7 +3292,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3008,7 +3312,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3026,7 +3332,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3044,7 +3352,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3062,7 +3372,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3080,7 +3392,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3098,7 +3412,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3116,7 +3432,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3134,7 +3452,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3152,7 +3472,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3170,7 +3492,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3188,7 +3512,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3206,7 +3532,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3224,7 +3552,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3242,7 +3572,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3260,7 +3592,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3278,7 +3612,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3296,7 +3632,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3314,7 +3652,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3332,7 +3672,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3350,7 +3692,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3368,7 +3712,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3386,7 +3732,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3404,7 +3752,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3422,7 +3772,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3440,7 +3792,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3458,7 +3812,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3476,7 +3832,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3494,7 +3852,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3512,7 +3872,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3530,7 +3892,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3548,7 +3912,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3566,7 +3932,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3584,7 +3952,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3602,7 +3972,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3620,7 +3992,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3638,7 +4012,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3656,7 +4032,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3674,7 +4052,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3692,7 +4072,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3710,7 +4092,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3728,7 +4112,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3746,7 +4132,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3764,7 +4152,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3782,7 +4172,9 @@
     ],
     "dataset": "voxceleb",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "easy",
     "split": "test-mini",
     "sub-category": "Phonemic Stress Pattern Analysis"
@@ -3800,7 +4192,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3818,7 +4212,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3836,7 +4232,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3854,7 +4252,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3872,7 +4272,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3890,7 +4292,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3908,7 +4312,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3926,7 +4332,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3944,7 +4352,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3962,7 +4372,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3980,7 +4392,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -3998,7 +4412,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4016,7 +4432,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4034,7 +4452,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4052,7 +4472,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4070,7 +4492,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4088,7 +4512,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4106,7 +4532,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4124,7 +4552,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4142,7 +4572,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -4160,7 +4592,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4178,7 +4612,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4196,7 +4632,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4214,7 +4652,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4232,7 +4672,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4250,7 +4692,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4268,7 +4712,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4286,7 +4732,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4304,7 +4752,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4322,7 +4772,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4340,7 +4792,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4358,7 +4812,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4376,7 +4832,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4394,7 +4852,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4412,7 +4872,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4430,7 +4892,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4448,7 +4912,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4466,7 +4932,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4484,7 +4952,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4502,7 +4972,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -4520,7 +4992,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4538,7 +5012,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4556,7 +5032,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4574,7 +5052,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4592,7 +5072,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4610,7 +5092,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4628,7 +5112,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4646,7 +5132,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4664,7 +5152,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4682,7 +5172,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4700,7 +5192,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4718,7 +5212,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4736,7 +5232,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4754,7 +5252,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4772,7 +5272,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4790,7 +5292,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4808,7 +5312,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4826,7 +5332,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4844,7 +5352,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4862,7 +5372,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -4880,7 +5392,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -4898,7 +5412,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -4916,7 +5432,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -4934,7 +5452,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -4952,7 +5472,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -4970,7 +5492,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -4988,7 +5512,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5006,7 +5532,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5024,7 +5552,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5042,7 +5572,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5060,7 +5592,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5078,7 +5612,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5096,7 +5632,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5114,7 +5652,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5132,7 +5672,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5150,7 +5692,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5168,7 +5712,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5186,7 +5732,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5204,7 +5752,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5222,7 +5772,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -5238,7 +5790,9 @@
     "answer": "wind",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5254,7 +5808,9 @@
     "answer": "Octavia",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5270,7 +5826,9 @@
     "answer": "crime",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5286,7 +5844,9 @@
     "answer": "sloppy",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5304,7 +5864,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5322,7 +5884,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5340,7 +5904,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5358,7 +5924,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5376,7 +5944,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5394,7 +5964,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5412,7 +5984,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5430,7 +6004,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5448,7 +6024,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5466,7 +6044,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5484,7 +6064,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5502,7 +6084,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5520,7 +6104,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5538,7 +6124,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5556,7 +6144,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5574,7 +6164,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5592,7 +6184,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5610,7 +6204,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5628,7 +6224,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5646,7 +6244,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5664,7 +6264,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5682,7 +6284,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5700,7 +6304,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5718,7 +6324,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5736,7 +6344,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5754,7 +6364,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5772,7 +6384,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5790,7 +6404,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5808,7 +6424,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5826,7 +6444,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion Flip Detection"
@@ -5844,7 +6464,9 @@
     "answer": "Male speech",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5862,7 +6484,9 @@
     "answer": "7.40 to 10.10",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -5880,7 +6504,9 @@
     "answer": "B:maj/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -5898,7 +6524,9 @@
     "answer": "Orchestra",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "medium",
     "split": "test-mini"
@@ -5916,7 +6544,9 @@
     "answer": "The G# major chord does not appear in any of the listed timeframes.",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -5934,7 +6564,9 @@
     "answer": "Melodic guitar",
     "dataset": "sdd",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5952,7 +6584,9 @@
     "answer": "Wide synth chords, sustained synth bass, and mellow bells",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -5970,7 +6604,9 @@
     "answer": "C major",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -5988,7 +6624,9 @@
     "answer": "Experimental hip hop beat",
     "dataset": "sdd",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6006,7 +6644,9 @@
     "answer": "A light",
     "dataset": "musidb",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6024,7 +6664,9 @@
     "answer": "She has decided she is not coming back.",
     "dataset": "jamendo",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -6042,7 +6684,9 @@
     "answer": "After the introduction",
     "dataset": "musiccaps",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6060,7 +6704,9 @@
     "answer": "Bass",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6078,7 +6724,9 @@
     "answer": "1.49 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -6096,7 +6744,9 @@
     "answer": "Bass drum",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6114,7 +6764,9 @@
     "answer": "A:maj(#11)/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6132,7 +6784,9 @@
     "answer": "A piano",
     "dataset": "sdd",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6150,7 +6804,9 @@
     "answer": "B:maj7/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6168,7 +6824,9 @@
     "answer": "Tinny bells, Synth strings, Shimmering hi hats",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6186,7 +6844,9 @@
     "answer": "D",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6204,7 +6864,9 @@
     "answer": "Peacefulness",
     "dataset": "musidb",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6222,7 +6884,9 @@
     "answer": "F#:maj7/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6240,7 +6904,9 @@
     "answer": "Approximately 2.0 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6258,7 +6924,9 @@
     "answer": "A:min/P5",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -6276,7 +6944,9 @@
     "answer": "Hip hop",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6294,7 +6964,9 @@
     "answer": "Piano",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6312,7 +6984,9 @@
     "answer": "Traditional animal horn",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6330,7 +7004,9 @@
     "answer": "C major",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6348,7 +7024,9 @@
     "answer": "A:7/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6366,7 +7044,9 @@
     "answer": "Cello",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6384,7 +7064,9 @@
     "answer": "C#:maj/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6402,7 +7084,9 @@
     "answer": "C#:maj7/5",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -6420,7 +7104,9 @@
     "answer": "F#:hdim7/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6438,7 +7124,9 @@
     "answer": "Piano",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6456,7 +7144,9 @@
     "answer": "Percussion",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6474,7 +7164,9 @@
     "answer": "Mechanical and impact sounds",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6492,7 +7184,9 @@
     "answer": "Starts minimalistic and becomes complex",
     "dataset": "sdd",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -6510,7 +7204,9 @@
     "answer": "1.98 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6528,7 +7224,9 @@
     "answer": "2.02 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6546,7 +7244,9 @@
     "answer": "Let them do it",
     "dataset": "jamendo",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6564,7 +7264,9 @@
     "answer": "Synthesizers and sound effects",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6582,7 +7284,9 @@
     "answer": "It was a mistake.",
     "dataset": "musidb",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -6600,7 +7304,9 @@
     "answer": "1.60 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6618,7 +7324,9 @@
     "answer": "Mostly acoustic instruments",
     "dataset": "sdd",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6636,7 +7344,9 @@
     "answer": "Electric guitar and bass guitar",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6654,7 +7364,9 @@
     "answer": "14.40s to 16.00s",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6672,7 +7384,9 @@
     "answer": "D#:min7/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6690,7 +7404,9 @@
     "answer": "Piano",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6708,7 +7424,9 @@
     "answer": "Guitar",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6726,7 +7444,9 @@
     "answer": "1.18 s",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6744,7 +7464,9 @@
     "answer": "2.14 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6762,7 +7484,9 @@
     "answer": "D:min/5",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -6780,7 +7504,9 @@
     "answer": "7.94",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -6798,7 +7524,9 @@
     "answer": "0.00 - 2.18",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6816,7 +7544,9 @@
     "answer": "Acoustic rhythm guitar",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6834,7 +7564,9 @@
     "answer": "0:09 - 0:11",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6852,7 +7584,9 @@
     "answer": "Electric Guitar and Bass Guitar",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6870,7 +7604,9 @@
     "answer": "1.00s to 2.00s",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6888,7 +7624,9 @@
     "answer": "E-guitar",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6906,7 +7644,9 @@
     "answer": "D:min/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6924,7 +7664,9 @@
     "answer": "Classical Guitar",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -6942,7 +7684,9 @@
     "answer": "B Major",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6960,7 +7704,9 @@
     "answer": "6.40 - 8.00",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6978,7 +7724,9 @@
     "answer": "Their identity",
     "dataset": "musidb",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -6996,7 +7744,9 @@
     "answer": "Banjo",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7014,7 +7764,9 @@
     "answer": "Trumpets, Trombones, and Tubas",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7032,7 +7784,9 @@
     "answer": "The singer is determined to not stop",
     "dataset": "musidb",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7050,7 +7804,9 @@
     "answer": "Sad and melancholic",
     "dataset": "musidb",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7068,7 +7824,9 @@
     "answer": "Accordion",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7086,7 +7844,9 @@
     "answer": "10.74 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -7104,7 +7864,9 @@
     "answer": "2.18",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7122,7 +7884,9 @@
     "answer": "Acoustic Guitar",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7140,7 +7904,9 @@
     "answer": "Flute and strings",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7158,7 +7924,9 @@
     "answer": "Where the sun will always shine",
     "dataset": "musidb",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7176,7 +7944,9 @@
     "answer": "Electric guitar and acoustic drums",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7194,7 +7964,9 @@
     "answer": "Amaj",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7212,7 +7984,9 @@
     "answer": "F#:maj7(*1)/5",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -7230,7 +8004,9 @@
     "answer": "E:7",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7248,7 +8024,9 @@
     "answer": "4.03",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7266,7 +8044,9 @@
     "answer": "It's already there but we cannot find it",
     "dataset": "jamendo",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Lyrical Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -7284,7 +8064,9 @@
     "answer": "Koto",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7302,7 +8084,9 @@
     "answer": "D:maj(2)/2",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7320,7 +8104,9 @@
     "answer": "G:maj/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -7338,7 +8124,9 @@
     "answer": "Vocals and bass",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7356,7 +8144,9 @@
     "answer": "Bells, water leaking, choir singing",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7374,7 +8164,9 @@
     "answer": "6.15 - 8.21",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7392,7 +8184,9 @@
     "answer": "Drums",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7410,7 +8204,9 @@
     "answer": "E:(1,5,2,6,4)/6",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7428,7 +8224,9 @@
     "answer": "Synth pads, bass, piano, kick, snare, hi hats",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7446,7 +8244,9 @@
     "answer": "B:min7/1",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7464,7 +8264,9 @@
     "answer": "1.62 - 3.24",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7482,7 +8284,9 @@
     "answer": "At the very beginning (0:00).",
     "dataset": "sdd",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7500,7 +8304,9 @@
     "answer": "C:maj/1 to G:maj/1 to A:min/5",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -7518,7 +8324,9 @@
     "answer": "1.63 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -7536,7 +8344,9 @@
     "answer": "9.60 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7554,7 +8364,9 @@
     "answer": "Flute",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7572,7 +8384,9 @@
     "answer": "Male singer",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7590,7 +8404,9 @@
     "answer": "Electric guitar, bass guitar, drums",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "easy",
     "split": "test-mini"
@@ -7608,7 +8424,9 @@
     "answer": "Violin and Cello",
     "dataset": "musicbench",
     "task": "music",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Instrumentation",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7626,7 +8444,9 @@
     "answer": "0.95 seconds",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "hard",
     "split": "test-mini"
@@ -7644,7 +8464,9 @@
     "answer": "4.80 - 7.20",
     "dataset": "guitarset",
     "task": "music",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Temporal Reasoning",
     "difficulty": "medium",
     "split": "test-mini"
@@ -7663,7 +8485,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "medium"
   },
@@ -7681,7 +8505,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "hard"
   },
@@ -7699,7 +8525,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "easy"
   },
@@ -7717,7 +8545,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "easy"
   },
@@ -7735,7 +8565,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "hard"
   },
@@ -7753,7 +8585,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "easy"
   },
@@ -7771,7 +8605,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "medium"
   },
@@ -7789,7 +8625,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "easy"
   },
@@ -7807,7 +8645,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "medium"
   },
@@ -7825,7 +8665,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "medium"
   },
@@ -7843,7 +8685,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "easy"
   },
@@ -7861,7 +8705,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "medium"
   },
@@ -7879,7 +8725,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "medium"
   },
@@ -7897,7 +8745,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "easy"
   },
@@ -7915,7 +8765,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "medium"
   },
@@ -7933,7 +8785,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "easy"
   },
@@ -7951,7 +8805,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "hard"
   },
@@ -7969,7 +8825,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "hard"
   },
@@ -7987,7 +8845,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "easy"
   },
@@ -8005,7 +8865,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Socio-cultural Interpretation",
     "difficulty": "hard"
   },
@@ -8023,7 +8885,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8041,7 +8905,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8059,7 +8925,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "hard"
   },
@@ -8077,7 +8945,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8095,7 +8965,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8113,7 +8985,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "hard"
   },
@@ -8131,7 +9005,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8149,7 +9025,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8167,7 +9045,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "hard"
   },
@@ -8185,7 +9065,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "hard"
   },
@@ -8203,7 +9085,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8221,7 +9105,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "easy"
   },
@@ -8239,7 +9125,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "easy"
   },
@@ -8257,7 +9145,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8275,7 +9165,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8293,7 +9185,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8311,7 +9205,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8329,7 +9225,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8347,7 +9245,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8365,7 +9265,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8383,7 +9285,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "easy"
   },
@@ -8401,7 +9305,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8419,7 +9325,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8437,7 +9345,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8455,7 +9365,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8473,7 +9385,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8491,7 +9405,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "easy"
   },
@@ -8509,7 +9425,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8527,7 +9445,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8545,7 +9465,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "easy"
   },
@@ -8563,7 +9485,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8581,7 +9505,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8599,7 +9525,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8617,7 +9545,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8635,7 +9565,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8653,7 +9585,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8671,7 +9605,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8689,7 +9625,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8707,7 +9645,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8725,7 +9665,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8743,7 +9685,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8761,7 +9705,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8779,7 +9725,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8797,7 +9745,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8815,7 +9765,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8833,7 +9785,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Rhythm and Tempo Understanding",
     "difficulty": "medium"
   },
@@ -8851,7 +9805,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -8869,7 +9825,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -8887,7 +9845,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -8905,7 +9865,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -8923,7 +9885,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -8941,7 +9905,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -8959,7 +9925,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -8977,7 +9945,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -8995,7 +9965,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9013,7 +9985,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9031,7 +10005,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9049,7 +10025,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9067,7 +10045,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9085,7 +10065,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9103,7 +10085,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "hard"
   },
@@ -9121,7 +10105,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9139,7 +10125,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9157,7 +10145,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9175,7 +10165,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9193,7 +10185,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9211,7 +10205,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9229,7 +10225,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "hard"
   },
@@ -9247,7 +10245,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9265,7 +10265,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "hard"
   },
@@ -9283,7 +10285,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9301,7 +10305,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9319,7 +10325,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9337,7 +10345,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9355,7 +10365,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9373,7 +10385,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9391,7 +10405,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9409,7 +10425,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9427,7 +10445,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "easy"
   },
@@ -9445,7 +10465,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Musical Texture Interpretation",
     "difficulty": "medium"
   },
@@ -9463,7 +10485,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9481,7 +10505,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9499,7 +10525,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "medium"
   },
@@ -9517,7 +10545,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "medium"
   },
@@ -9535,7 +10565,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9553,7 +10585,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9571,7 +10605,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9589,7 +10625,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9607,7 +10645,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9625,7 +10665,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9643,7 +10685,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9661,7 +10705,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9679,7 +10725,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9697,7 +10745,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9715,7 +10765,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9733,7 +10785,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "medium"
   },
@@ -9751,7 +10805,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9769,7 +10825,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9787,7 +10845,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9805,7 +10865,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "medium"
   },
@@ -9823,7 +10885,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9841,7 +10905,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9859,7 +10925,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9877,7 +10945,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9895,7 +10965,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9913,7 +10985,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9931,7 +11005,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9949,7 +11025,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9967,7 +11045,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -9985,7 +11065,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -10003,7 +11085,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -10021,7 +11105,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "easy"
   },
@@ -10039,7 +11125,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Melodic Structure Interpretation",
     "difficulty": "medium"
   },
@@ -10057,7 +11145,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10075,7 +11165,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10093,7 +11185,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10111,7 +11205,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10129,7 +11225,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10147,7 +11245,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10165,7 +11265,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "easy"
   },
@@ -10183,7 +11285,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10201,7 +11305,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "easy"
   },
@@ -10219,7 +11325,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10237,7 +11345,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10255,7 +11365,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10273,7 +11385,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "easy"
   },
@@ -10291,7 +11405,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "easy"
   },
@@ -10309,7 +11425,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10327,7 +11445,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "easy"
   },
@@ -10345,7 +11465,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10363,7 +11485,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10381,7 +11505,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10399,7 +11525,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10417,7 +11545,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10435,7 +11565,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10453,7 +11585,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10471,7 +11605,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10489,7 +11625,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10507,7 +11645,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10525,7 +11665,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "easy"
   },
@@ -10543,7 +11685,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10561,7 +11705,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10579,7 +11725,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10597,7 +11745,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10615,7 +11765,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10633,7 +11785,9 @@
     "dataset": "musicbench",
     "task": "music",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Harmony and Chord Progressions",
     "difficulty": "medium"
   },
@@ -10651,7 +11805,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10669,7 +11825,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -10687,7 +11845,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10705,7 +11865,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10723,7 +11885,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -10741,7 +11905,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10759,7 +11925,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -10777,7 +11945,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -10795,7 +11965,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10813,7 +11985,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -10831,7 +12005,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10849,7 +12025,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -10867,7 +12045,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10885,7 +12065,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -10903,7 +12085,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "hard"
   },
@@ -10921,7 +12105,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "hard"
   },
@@ -10939,7 +12125,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10957,7 +12145,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10975,7 +12165,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -10993,7 +12185,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "hard"
   },
@@ -11011,7 +12205,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "hard"
   },
@@ -11029,7 +12225,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "hard"
   },
@@ -11047,7 +12245,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -11065,7 +12265,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "hard"
   },
@@ -11083,7 +12285,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -11101,7 +12305,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -11119,7 +12325,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -11137,7 +12345,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "easy"
   },
@@ -11155,7 +12365,9 @@
     "dataset": "fma_large",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "hard"
   },
@@ -11173,7 +12385,9 @@
     "dataset": "fma_large",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -11191,7 +12405,9 @@
     "dataset": "fma_large",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -11209,7 +12425,9 @@
     "dataset": "fma_large",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -11227,7 +12445,9 @@
     "dataset": "fma_large",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -11245,7 +12465,9 @@
     "dataset": "fma_large",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Musical Genre Reasoning",
     "difficulty": "medium"
   },
@@ -11263,7 +12485,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11281,7 +12505,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11299,7 +12525,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11317,7 +12545,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11335,7 +12565,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11353,7 +12585,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11371,7 +12605,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11389,7 +12625,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11407,7 +12645,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11425,7 +12665,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11443,7 +12685,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11461,7 +12705,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11479,7 +12725,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11497,7 +12745,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11515,7 +12765,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11533,7 +12785,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11551,7 +12805,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11569,7 +12825,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11587,7 +12845,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11605,7 +12865,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11623,7 +12885,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11641,7 +12905,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11659,7 +12925,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11677,7 +12945,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11695,7 +12965,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11713,7 +12985,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11731,7 +13005,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11749,7 +13025,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11767,7 +13045,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11785,7 +13065,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11803,7 +13085,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11821,7 +13105,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11839,7 +13125,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11857,7 +13145,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11875,7 +13165,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11893,7 +13185,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11911,7 +13205,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11929,7 +13225,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11947,7 +13245,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11965,7 +13265,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -11983,7 +13285,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -12001,7 +13305,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -12019,7 +13325,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -12037,7 +13345,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -12055,7 +13365,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -12073,7 +13385,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -12091,7 +13405,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -12109,7 +13425,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Event-Based Sound Reasoning",
     "difficulty": "medium"
   },
@@ -12127,7 +13445,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12145,7 +13465,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12163,7 +13485,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12181,7 +13505,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12199,7 +13525,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12217,7 +13545,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12235,7 +13565,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12253,7 +13585,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12271,7 +13605,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12289,7 +13625,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12307,7 +13645,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12325,7 +13665,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12343,7 +13685,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12361,7 +13705,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12379,7 +13725,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12397,7 +13745,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12415,7 +13765,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12433,7 +13785,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12451,7 +13805,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12469,7 +13825,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12487,7 +13845,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12505,7 +13865,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12523,7 +13885,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12541,7 +13905,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12559,7 +13925,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12577,7 +13945,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12595,7 +13965,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "medium"
   },
@@ -12613,7 +13985,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12631,7 +14005,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12649,7 +14025,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12667,7 +14045,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12685,7 +14065,9 @@
     "dataset": "musiccaps",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "easy"
   },
@@ -12703,7 +14085,9 @@
     "dataset": "sdd",
     "task": "music",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Emotional Tone Interpretation",
     "difficulty": "hard"
   },
@@ -12721,7 +14105,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12739,7 +14125,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12757,7 +14145,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12775,7 +14165,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12793,7 +14185,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12811,7 +14205,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12829,7 +14225,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12847,7 +14245,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12865,7 +14265,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12883,7 +14285,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12901,7 +14305,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12919,7 +14325,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12937,7 +14345,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12955,7 +14365,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12973,7 +14385,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -12991,7 +14405,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13009,7 +14425,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13027,7 +14445,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13045,7 +14465,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13063,7 +14485,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13081,7 +14505,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13099,7 +14525,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13117,7 +14545,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13135,7 +14565,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13153,7 +14585,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13171,7 +14605,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13193,7 +14629,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13211,7 +14649,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13229,7 +14669,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13247,7 +14689,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13265,7 +14709,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13283,7 +14729,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13301,7 +14749,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13319,7 +14769,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13337,7 +14789,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13355,7 +14809,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13373,7 +14829,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13391,7 +14849,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13409,7 +14869,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13427,7 +14889,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13445,7 +14909,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13463,7 +14929,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13481,7 +14949,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13499,7 +14969,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13517,7 +14989,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13535,7 +15009,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13553,7 +15029,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Eco-Acoustic Knowledge",
     "difficulty": "medium"
   },
@@ -13571,7 +15049,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13589,7 +15069,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13607,7 +15089,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13625,7 +15109,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13643,7 +15129,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13661,7 +15149,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13679,7 +15169,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13697,7 +15189,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13715,7 +15209,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13733,7 +15229,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13751,7 +15249,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13769,7 +15269,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13787,7 +15289,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13805,7 +15309,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13823,7 +15329,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13841,7 +15349,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13859,7 +15369,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13877,7 +15389,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13895,7 +15409,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13913,7 +15429,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13931,7 +15449,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13949,7 +15469,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13967,7 +15489,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -13985,7 +15509,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14003,7 +15529,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14021,7 +15549,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14039,7 +15569,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14057,7 +15589,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14075,7 +15609,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14093,7 +15629,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14111,7 +15649,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14129,7 +15669,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14147,7 +15689,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14165,7 +15709,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14183,7 +15729,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14201,7 +15749,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14219,7 +15769,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14237,7 +15789,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14255,7 +15809,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14273,7 +15829,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14291,7 +15849,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14309,7 +15869,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14327,7 +15889,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14345,7 +15909,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14363,7 +15929,9 @@
     "dataset": "AudioSet_SL",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14381,7 +15949,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14399,7 +15969,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14417,7 +15989,9 @@
     "dataset": "synthetic",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Ambient Sound Interpretation",
     "difficulty": "hard"
   },
@@ -14435,7 +16009,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14453,7 +16029,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14471,7 +16049,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14489,7 +16069,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14507,7 +16089,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14525,7 +16109,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14543,7 +16129,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14561,7 +16149,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14579,7 +16169,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14597,7 +16189,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14615,7 +16209,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14633,7 +16229,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14651,7 +16249,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14669,7 +16269,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14687,7 +16289,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14705,7 +16309,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14723,7 +16329,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14741,7 +16349,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14759,7 +16369,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14777,7 +16389,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14795,7 +16409,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14813,7 +16429,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14831,7 +16449,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14849,7 +16469,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14867,7 +16489,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14885,7 +16509,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14903,7 +16529,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14921,7 +16549,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14939,7 +16569,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14957,7 +16589,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14975,7 +16609,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -14993,7 +16629,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15011,7 +16649,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15029,7 +16669,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15047,7 +16689,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15065,7 +16709,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15083,7 +16729,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15101,7 +16749,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15119,7 +16769,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15137,7 +16789,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15155,7 +16809,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15173,7 +16829,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15191,7 +16849,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15209,7 +16869,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15227,7 +16889,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15245,7 +16909,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15263,7 +16929,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15281,7 +16949,9 @@
     "dataset": "Clotho",
     "task": "sound",
     "split": "test-mini",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "sub-category": "Acoustic Scene Reasoning",
     "difficulty": "medium"
   },
@@ -15299,7 +16969,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15317,7 +16989,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15335,7 +17009,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15353,7 +17029,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15371,7 +17049,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15389,7 +17069,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15407,7 +17089,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15425,7 +17109,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15443,7 +17129,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15461,7 +17149,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15479,7 +17169,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15497,7 +17189,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15515,7 +17209,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15533,7 +17229,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15551,7 +17249,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15569,7 +17269,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15587,7 +17289,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15605,7 +17309,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15623,7 +17329,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15641,7 +17349,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15659,7 +17369,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15677,7 +17389,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15695,7 +17409,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15713,7 +17429,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15731,7 +17449,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15749,7 +17469,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15767,7 +17489,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15785,7 +17509,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15803,7 +17529,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15821,7 +17549,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15839,7 +17569,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15857,7 +17589,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15875,7 +17609,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15893,7 +17629,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15911,7 +17649,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15929,7 +17669,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15947,7 +17689,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15965,7 +17709,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -15983,7 +17729,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -16001,7 +17749,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -16019,7 +17769,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -16037,7 +17789,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -16055,7 +17809,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -16073,7 +17829,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -16091,7 +17849,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -16109,7 +17869,9 @@
     "dataset": "AudioSet",
     "task": "sound",
     "split": "test-mini",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Sound-Based Event Recognition",
     "difficulty": "medium"
   },
@@ -16126,7 +17888,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16144,7 +17908,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16162,7 +17928,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16180,7 +17948,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16198,7 +17968,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16216,7 +17988,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16234,7 +18008,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16252,7 +18028,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16270,7 +18048,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16288,7 +18068,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16306,7 +18088,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16324,7 +18108,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16342,7 +18128,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16360,7 +18148,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16378,7 +18168,9 @@
     ],
     "dataset": "mustard",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Dissonant Emotion Interpretation"
@@ -16396,7 +18188,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16414,7 +18208,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16432,7 +18228,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16450,7 +18248,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16468,7 +18268,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16486,7 +18288,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16504,7 +18308,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16522,7 +18328,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16540,7 +18348,9 @@
     ],
     "dataset": "AudioSet_SL",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16558,7 +18368,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16576,7 +18388,9 @@
     ],
     "dataset": "AudioSet_SL",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16594,7 +18408,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16612,7 +18428,9 @@
     ],
     "dataset": "AudioSet_SL",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Event-Based Knowledge Retrieval"
@@ -16630,7 +18448,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16648,7 +18468,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16666,7 +18488,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16684,7 +18508,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16702,7 +18528,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16720,7 +18548,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16738,7 +18568,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16756,7 +18588,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16774,7 +18608,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Counting"
@@ -16793,7 +18629,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16812,7 +18650,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16831,7 +18671,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16850,7 +18692,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16869,7 +18713,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16888,7 +18734,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16907,7 +18755,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16926,7 +18776,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16945,7 +18797,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16964,7 +18818,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -16983,7 +18839,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17002,7 +18860,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17021,7 +18881,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17040,7 +18902,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17059,7 +18923,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17078,7 +18944,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17097,7 +18965,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17116,7 +18986,9 @@
     ],
     "dataset": "meld",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17135,7 +19007,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17154,7 +19028,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17173,7 +19049,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17192,7 +19070,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17211,7 +19091,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17230,7 +19112,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "hard",
     "split": "test-mini",
     "sub-category": "Emotion State summarisation"
@@ -17248,7 +19132,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -17266,7 +19152,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Conversational Fact Retrieval"
@@ -17284,7 +19172,9 @@
     ],
     "dataset": "iemocap",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Key highlight Extraction"
@@ -17302,7 +19192,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -17320,7 +19212,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -17338,7 +19232,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -17356,7 +19252,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -17374,7 +19272,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -17392,7 +19292,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -17410,7 +19312,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Reasoning",
+    "category": [
+      "Reasoning"
+    ],
     "difficulty": "medium",
     "split": "test-mini",
     "sub-category": "Multi Speaker Role Mapping"
@@ -17426,7 +19330,9 @@
     "answer": "push-ups",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17442,7 +19348,9 @@
     "answer": "ghastly",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17458,7 +19366,9 @@
     "answer": "Handy",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17474,7 +19384,9 @@
     "answer": "fine",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17490,7 +19402,9 @@
     "answer": "dogs",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17506,7 +19420,9 @@
     "answer": "red",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17522,7 +19438,9 @@
     "answer": "purple",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17538,7 +19456,9 @@
     "answer": "great-grandma",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17554,7 +19474,9 @@
     "answer": "wishful",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17570,7 +19492,9 @@
     "answer": "Phillip",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17586,7 +19510,9 @@
     "answer": "breath",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17602,7 +19528,9 @@
     "answer": "Jerry",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17618,7 +19546,9 @@
     "answer": "wristwatch",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17634,7 +19564,9 @@
     "answer": "switch",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17650,7 +19582,9 @@
     "answer": "teachers",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17666,7 +19600,9 @@
     "answer": "wish",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17682,7 +19618,9 @@
     "answer": "boards",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17698,7 +19636,9 @@
     "answer": "garbling",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17714,7 +19654,9 @@
     "answer": "red",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17730,7 +19672,9 @@
     "answer": "lump",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17746,7 +19690,9 @@
     "answer": "crazy",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17762,7 +19708,9 @@
     "answer": "hedge",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17778,7 +19726,9 @@
     "answer": "another",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17796,7 +19746,9 @@
     "answer": "Blaire",
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17814,7 +19766,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17832,7 +19786,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17850,7 +19806,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17868,7 +19826,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17886,7 +19846,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17904,7 +19866,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17922,7 +19886,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17940,7 +19906,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17958,7 +19926,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17976,7 +19946,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"
@@ -17994,7 +19966,9 @@
     ],
     "dataset": "synthetic",
     "task": "speech",
-    "category": "Information Extraction",
+    "category": [
+      "Information Extraction"
+    ],
     "sub-category": "Phonological Sequence Decoding",
     "difficulty": "easy",
     "split": "test-mini"


### PR DESCRIPTION
# Fix inconsistent data types in MMAU test dataset

## Issue
The MMAU test dataset JSON file contains inconsistent data types for the `category` field:
- Some entries have `category` as a string: `"category": "Reasoning"`
- Others have it as a list of strings: `"category": ["Reasoning"]`

This inconsistency causes Arrow conversion errors when loading the dataset using HuggingFace's datasets library:
```python
ArrowTypeError: ("Expected bytes, got a 'list' object", 'Conversion failed for column category with type object')
```

## Fix
Normalized the `category` field to consistently use a list format across all entries. This allows the dataset to be loaded directly using:
```python
from datasets import load_dataset
dataset = load_dataset('json', data_files="path/to/mmau-test-mini.json")
```

### Changes
- Modified data preprocessing to ensure `category` is always a list of strings
- If `category` is a string, it's converted to a single-element list: `"Reasoning"` → `["Reasoning"]`
- Existing list entries remain unchanged

### Testing
- Verified that all entries in the JSON have consistent types
- Confirmed successful loading using HuggingFace datasets library
- Tested MMAU evaluation pipeline with the normalized dataset

## Additional Notes
This change is backwards compatible as the MMAU evaluation code already handles both string and list formats for categories.